### PR TITLE
Ignore messages from OwnTracks without lat/lon (control messages).

### DIFF
--- a/lib/Controller/LogController.php
+++ b/lib/Controller/LogController.php
@@ -1934,8 +1934,8 @@ class LogController extends Controller {
 	 *
 	 * Owntracks IOS
 	 * @param string $token
-	 * @param float $lat
-	 * @param float $lon
+	 * @param float|null $lat
+	 * @param float|null $lon
 	 * @param string|null $devicename
 	 * @param string|null $tid
 	 * @param float|null $alt
@@ -1944,8 +1944,12 @@ class LogController extends Controller {
 	 * @param float|null $batt
 	 * @return mixed
 	 */
-	public function logOwntracks(string $token, float $lat, float $lon, ?string $devicename = null, ?string $tid = null,
+	public function logOwntracks(string $token, ?float $lat, ?float $lon, ?string $devicename = null, ?string $tid = null,
 								 ?float $alt = null, ?int $tst = null, ?float $acc = null, ?float $batt = null) {
+		if (is_null($lat)) {
+			// empty message (control message?) - ignore
+			return ['result' => 'ok'];
+		}
 		$dname = $this->chooseDeviceName($devicename, $tid);
 		$res = $this->logPost($token, $dname, $lat, $lon, $alt, $tst, $acc, $batt, null, self::LOG_OWNTRACKS);
 		return $res['friends'];

--- a/lib/Controller/LogController.php
+++ b/lib/Controller/LogController.php
@@ -1946,7 +1946,7 @@ class LogController extends Controller {
 	 */
 	public function logOwntracks(string $token, ?float $lat, ?float $lon, ?string $devicename = null, ?string $tid = null,
 								 ?float $alt = null, ?int $tst = null, ?float $acc = null, ?float $batt = null) {
-		if (is_null($lat)) {
+		if (is_null($lat) || is_null($lon)) {
 			// empty message (control message?) - ignore
 			return ['result' => 'ok'];
 		}


### PR DESCRIPTION
OwnTracks control messages run into error which makes OwnTracks try again and again.

If you e.g. swipe-delete an entry from the Friends list in OwnTracks, it tries to send that event to the server. This message has no lat/lon info and thus PhoneTrack returns an error. This causes OwnTracks to queue the control messages to try again and all subsequent location messages go to the queue as well - halting location logging into PhoneTrack completely. (Because it can't get the control message to go through.)

This change just ignores these messages and returns HTTP 200 so OwnTracks continues pushing the rest of the queue.