### PR TITLE
Reorder OwnTracks friends SQL query for improved performance

### DIFF
--- a/lib/Controller/LogController.php
+++ b/lib/Controller/LogController.php
@@ -1428,14 +1428,14 @@ class LogController extends Controller {
 								`timestamp`
 							FROM `*PREFIX*phonetrack_points` p
 							JOIN (
-								SELECT `deviceid`, `nametoken`, `name`,
+								SELECT `deviceid`,
 									MAX(`timestamp`) `lastupdate`
 								FROM `*PREFIX*phonetrack_points` po
-								JOIN `*PREFIX*phonetrack_devices` d ON po.`deviceid` = d.`id`
-								WHERE `sessionid` = ?
-								GROUP BY `deviceid`, `nametoken`, `name`
+								GROUP BY `deviceid`
 							) l ON p.`deviceid` = l.`deviceid`
 							AND p.`timestamp` = l.`lastupdate`
+							JOIN `*PREFIX*phonetrack_devices` d ON p.`deviceid` = d.`id`
+							WHERE `sessionid` = ?
 						';
 						$friendReq = $this->dbconnection->prepare($friendSQL);
 						$friendReq->execute([$token]);


### PR DESCRIPTION
Previous query joined the whole of _points to _devices before filtering. That one took between 10 and 16 seconds for me. (2.5m points in an SQLite database) This caused OwnTracks to fail to log in the background most of the time.

Moved the JOIN to the outer query which reduced the time to 3 seconds.

While this will now first find the latest points for ALL devices and filter them afterwards for the specified `sessionid`, it works a lot faster for me because it can make use of the indexes.