### PR TITLE
Fix the broken export of Session tracks to GPX

### DIFF
--- a/lib/Service/SessionService.php
+++ b/lib/Service/SessionService.php
@@ -342,7 +342,7 @@ class SessionService {
 					$sqldev = '
 						SELECT dev.id AS id, dev.name AS name
 						FROM *PREFIX*phonetrack_devices AS dev, *PREFIX*phonetrack_points AS po
-						WHERE dev.sessionid=' . $this->db_quote_escape_string($sessionToken) . ' AND dev.id = po.deviceid GROUP BY dev.id;';
+						WHERE dev.sessionid=' . $this->db_quote_escape_string($sessionToken) . ' AND dev.id = po.deviceid GROUP BY dev.id, dev.name;';
 					$req = $this->db->prepare($sqldev);
 					$res = $req->execute();
 					while ($row = $res->fetch()) {


### PR DESCRIPTION
Fixes this SQL Error when trying to export a Session to GPX

ERROR:
column "dev.name" must appear in the GROUP BY clause or be used in an aggregate function at character 29

STATEMENT: 
SELECT dev.id AS id, dev.name AS name
FROM oc_phonetrack_devices AS dev, oc_phonetrack_points AS po WHERE dev.sessionid='xxxxx' AND dev.id = po.deviceid GROUP BY dev.id;