### PR TITLE
PageController: Add sensible default limit

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -4089,7 +4089,7 @@ class PageController extends Controller {
 				$req->closeCursor();
 
 				$entries = [];
-				$sqlLimit = '';
+				$sqlLimit = 'LIMIT 1000';
 				if (is_numeric($limit)) {
 					$sqlLimit = 'LIMIT '.intval($limit);
 				}


### PR DESCRIPTION
In instances where a limit parameter is not specified, having hundreds of thousands of recorded points causes unreasonable server load and takes far too much time, often resulting in timeout before the data is received by the client.

This commit adds a sensible default of 1000 points. More points can be retrieved by setting a higher limit.