### PR TITLE
fix nonsensical literal German translation

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -109,7 +109,7 @@ OC.L10N.register(
     "Ulogger link" : "Ulogger-Link",
     "Traccar link" : "Traccar-Link",
     "OpenGTS link" : "OpenGTS-Link",
-    "Overland link" : "Überlandverbindung",
+    "Overland link" : "Overland-Link",
     "Locus Map link" : "Locus-Map-Link",
     "HTTP GET link" : "HTTP-GET-Link",
     "The session you want to delete does not exist" : "Die zu löschende Sitzung ist nicht vorhanden",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -107,7 +107,7 @@
     "Ulogger link" : "Ulogger-Link",
     "Traccar link" : "Traccar-Link",
     "OpenGTS link" : "OpenGTS-Link",
-    "Overland link" : "Überlandverbindung",
+    "Overland link" : "Overland-Link",
     "Locus Map link" : "Locus-Map-Link",
     "HTTP GET link" : "HTTP-GET-Link",
     "The session you want to delete does not exist" : "Die zu löschende Sitzung ist nicht vorhanden",

--- a/translationfiles/de_DE/phonetrack.po
+++ b/translationfiles/de_DE/phonetrack.po
@@ -489,7 +489,7 @@ msgstr "OpenGTS-Link"
 
 #: /var/www/html/dev/server/apps/phonetrack/src/phonetrack.js:1862
 msgid "Overland link"
-msgstr "Überlandverbindung"
+msgstr "Overland-Link"
 
 #: /var/www/html/dev/server/apps/phonetrack/src/phonetrack.js:1866
 msgid "Locus Map link"


### PR DESCRIPTION
This PR fixes the German translation of the URL description for the Phonetrack API endpoint that is supposed be used in the iOS tracking app "Overland". It had been a literal translation of the word "overland" (Überland) and "link" (Verbindung), which obviously doesn't make a lot of sense as the app is still called Overland even for German users.