### PR TITLE
Update PhonetrackProvider.php

### DIFF
--- a/lib/Activity/PhonetrackProvider.php
+++ b/lib/Activity/PhonetrackProvider.php
@@ -77,7 +77,7 @@ class PhonetrackProvider implements IProvider {
 			$params = [
 				'user' => [
 					'type' => 'user',
-					'id' => 0,
+					'id' => '0',
 					'name' => $subjectParams['author']
 				],
 			];


### PR DESCRIPTION
I blatantly stole this from https://github.com/julien-nc/cospend-nc/pull/352.
I do not know the first thing about programming, but maybe someone can verify this change and subsequently fix the errors I get since upgrading to NC 31.0.0 (I think):
`[phonetrack] Error: Activity event had invalid subject parameters provided [app: phonetrack, subject: PhoneTrack device {device} of session {session} has entered geofence {geofence}]`