### PR TITLE
Fix missing device columns when migrating from <1.0

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -3,7 +3,7 @@
     <id>phonetrack</id>
     <name>PhoneTrack</name>
     <summary> </summary><description> </description>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <licence>agpl</licence>
     <author mail="julien-nc@posteo.net">Julien Veyssier</author>
     <namespace>PhoneTrack</namespace>

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "bamarni/composer-bin-plugin",
-            "version": "1.9.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bamarni/composer-bin-plugin.git",
-                "reference": "f6af6be0534fad47b38b34311e7d6148a67b5587"
+                "reference": "641d0663f5ac270b1aeec4337b7856f76204df47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/f6af6be0534fad47b38b34311e7d6148a67b5587",
-                "reference": "f6af6be0534fad47b38b34311e7d6148a67b5587",
+                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/641d0663f5ac270b1aeec4337b7856f76204df47",
+                "reference": "641d0663f5ac270b1aeec4337b7856f76204df47",
                 "shasum": ""
             },
             "require": {
@@ -25,7 +25,7 @@
                 "php": "^7.2.5 || ^8.0"
             },
             "require-dev": {
-                "composer/composer": "^2.6",
+                "composer/composer": "^2.2.26",
                 "ext-json": "*",
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan": "^1.8 || ^2.0",
@@ -59,9 +59,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bamarni/composer-bin-plugin/issues",
-                "source": "https://github.com/bamarni/composer-bin-plugin/tree/1.9.0"
+                "source": "https://github.com/bamarni/composer-bin-plugin/tree/1.9.1"
             },
-            "time": "2026-01-29T23:07:38+00:00"
+            "time": "2026-02-04T10:18:12+00:00"
         }
     ],
     "packages-dev": [
@@ -140,16 +140,16 @@
         },
         {
             "name": "kubawerlos/php-cs-fixer-custom-fixers",
-            "version": "v3.36.0",
+            "version": "v3.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers.git",
-                "reference": "e1f97f6463f0b2a22e0dd320948a04132ff9c501"
+                "reference": "c31fb2aa359dcb25fb48cc6f600810ad284343be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kubawerlos/php-cs-fixer-custom-fixers/zipball/e1f97f6463f0b2a22e0dd320948a04132ff9c501",
-                "reference": "e1f97f6463f0b2a22e0dd320948a04132ff9c501",
+                "url": "https://api.github.com/repos/kubawerlos/php-cs-fixer-custom-fixers/zipball/c31fb2aa359dcb25fb48cc6f600810ad284343be",
+                "reference": "c31fb2aa359dcb25fb48cc6f600810ad284343be",
                 "shasum": ""
             },
             "require": {
@@ -180,7 +180,7 @@
             "description": "A set of custom fixers for PHP CS Fixer",
             "support": {
                 "issues": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/issues",
-                "source": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.36.0"
+                "source": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.37.0"
             },
             "funding": [
                 {
@@ -188,7 +188,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-31T07:02:11+00:00"
+            "time": "2026-04-16T16:49:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -301,12 +301,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "a101733a740e3264643b76f6489515cb27c43c99"
+                "reference": "1e8078631ee2c4da77e39fd7addebd1837889298"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/a101733a740e3264643b76f6489515cb27c43c99",
-                "reference": "a101733a740e3264643b76f6489515cb27c43c99",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/1e8078631ee2c4da77e39fd7addebd1837889298",
+                "reference": "1e8078631ee2c4da77e39fd7addebd1837889298",
                 "shasum": ""
             },
             "require": {
@@ -314,6 +314,7 @@
                 "psr/clock": "^1.0",
                 "psr/container": "^2.0.2",
                 "psr/event-dispatcher": "^1.0",
+                "psr/http-client": "^1.0.3",
                 "psr/log": "^3.0.2"
             },
             "default-branch": true,
@@ -342,7 +343,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2026-01-29T01:05:54+00:00"
+            "time": "2026-04-25T01:21:25+00:00"
         },
         {
             "name": "nextcloud/openapi-extractor",
@@ -569,16 +570,16 @@
         },
         {
             "name": "php-cs-fixer/shim",
-            "version": "v3.93.1",
+            "version": "v3.95.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/shim.git",
-                "reference": "3a9db22e8f01762fddd3a85b998053294c5a3629"
+                "reference": "f81ccf51ca60cc9dd21358ffba0e79ebd2ebb78a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/3a9db22e8f01762fddd3a85b998053294c5a3629",
-                "reference": "3a9db22e8f01762fddd3a85b998053294c5a3629",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/f81ccf51ca60cc9dd21358ffba0e79ebd2ebb78a",
+                "reference": "f81ccf51ca60cc9dd21358ffba0e79ebd2ebb78a",
                 "shasum": ""
             },
             "require": {
@@ -615,9 +616,9 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/shim/issues",
-                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.93.1"
+                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.95.1"
             },
-            "time": "2026-01-28T23:51:14+00:00"
+            "time": "2026-04-12T17:00:34+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -668,16 +669,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.5.2",
+            "version": "12.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "4a9739b51cbcb355f6e95659612f92e282a7077b"
+                "reference": "876099a072646c7745f673d7aeab5382c4439691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4a9739b51cbcb355f6e95659612f92e282a7077b",
-                "reference": "4a9739b51cbcb355f6e95659612f92e282a7077b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/876099a072646c7745f673d7aeab5382c4439691",
+                "reference": "876099a072646c7745f673d7aeab5382c4439691",
                 "shasum": ""
             },
             "require": {
@@ -686,7 +687,6 @@
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^5.7.0",
                 "php": ">=8.3",
-                "phpunit/php-file-iterator": "^6.0",
                 "phpunit/php-text-template": "^5.0",
                 "sebastian/complexity": "^5.0",
                 "sebastian/environment": "^8.0.3",
@@ -733,7 +733,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.2"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.6"
             },
             "funding": [
                 {
@@ -753,20 +753,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-24T07:03:04+00:00"
+            "time": "2026-04-15T08:23:17+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "6.0.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "961bc913d42fe24a257bfff826a5068079ac7782"
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/961bc913d42fe24a257bfff826a5068079ac7782",
-                "reference": "961bc913d42fe24a257bfff826a5068079ac7782",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
                 "shasum": ""
             },
             "require": {
@@ -806,15 +806,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.0"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:58:37+00:00"
+            "time": "2026-02-02T14:04:18+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -1002,16 +1014,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.8",
+            "version": "12.5.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "37ddb96c14bfee10304825edbb7e66d341ec6889"
+                "reference": "c54fcf3d6bcb6e96ac2f7e40097dc37b5f139969"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/37ddb96c14bfee10304825edbb7e66d341ec6889",
-                "reference": "37ddb96c14bfee10304825edbb7e66d341ec6889",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c54fcf3d6bcb6e96ac2f7e40097dc37b5f139969",
+                "reference": "c54fcf3d6bcb6e96ac2f7e40097dc37b5f139969",
                 "shasum": ""
             },
             "require": {
@@ -1025,18 +1037,19 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.5.2",
-                "phpunit/php-file-iterator": "^6.0.0",
+                "phpunit/php-code-coverage": "^12.5.6",
+                "phpunit/php-file-iterator": "^6.0.1",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
                 "phpunit/php-timer": "^8.0.0",
                 "sebastian/cli-parser": "^4.2.0",
-                "sebastian/comparator": "^7.1.4",
+                "sebastian/comparator": "^7.1.6",
                 "sebastian/diff": "^7.0.0",
-                "sebastian/environment": "^8.0.3",
+                "sebastian/environment": "^8.1.0",
                 "sebastian/exporter": "^7.0.2",
                 "sebastian/global-state": "^8.0.2",
                 "sebastian/object-enumerator": "^7.0.0",
+                "sebastian/recursion-context": "^7.0.1",
                 "sebastian/type": "^6.0.3",
                 "sebastian/version": "^6.0.0",
                 "staabm/side-effects-detector": "^1.0.5"
@@ -1079,31 +1092,15 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.8"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.23"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2026-01-27T06:12:29+00:00"
+            "time": "2026-04-18T06:12:49+00:00"
         },
         {
             "name": "psr/clock",
@@ -1257,6 +1254,111 @@
             "time": "2019-01-08T18:20:26+00:00"
         },
         {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "3.0.2",
             "source": {
@@ -1377,16 +1479,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "7.1.4",
+            "version": "7.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "6a7de5df2e094f9a80b40a522391a7e6022df5f6"
+                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a7de5df2e094f9a80b40a522391a7e6022df5f6",
-                "reference": "6a7de5df2e094f9a80b40a522391a7e6022df5f6",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c769009dee98f494e0edc3fd4f4087501688f11e",
+                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e",
                 "shasum": ""
             },
             "require": {
@@ -1445,7 +1547,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.4"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.6"
             },
             "funding": [
                 {
@@ -1465,7 +1567,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T09:28:48+00:00"
+            "time": "2026-04-14T08:23:15+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -1594,16 +1696,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "8.0.3",
+            "version": "8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68"
+                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
-                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/b121608b28a13f721e76ffbbd386d08eff58f3f6",
+                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6",
                 "shasum": ""
             },
             "require": {
@@ -1618,7 +1720,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.0-dev"
+                    "dev-main": "8.1-dev"
                 }
             },
             "autoload": {
@@ -1646,7 +1748,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/8.0.3"
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.1.0"
             },
             "funding": [
                 {
@@ -1666,7 +1768,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-12T14:11:56+00:00"
+            "time": "2026-04-15T12:13:01+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -2318,5 +2420,5 @@
         "ext-xml": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/lib/Activity/ActivityManager.php
+++ b/lib/Activity/ActivityManager.php
@@ -172,7 +172,7 @@ class ActivityManager {
 			->setAuthor($author ?? $this->userId ?? '')
 			->setObject($objectType, (int)$object->getId(), $objectName)
 			->setSubject($subject, array_merge($subjectParams, $additionalParams))
-			->setLink($this->url->linkToRouteAbsolute('phonetrack.page.index'))
+			->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'))
 			->setTimestamp(time());
 
 		return $event;

--- a/lib/Controller/LogController.php
+++ b/lib/Controller/LogController.php
@@ -36,9 +36,11 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IURLGenerator;
 use OCP\IUserManager;
 
 use OCP\Mail\IMailer;
+use OCP\Notification\IAction;
 use OCP\Notification\IManager;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -66,6 +68,7 @@ class LogController extends Controller {
 		private ShareMapper $shareMapper,
 		private IDBConnection $db,
 		private IMailer $mailer,
+		private IURLGenerator $url,
 		private ?string $userId,
 	) {
 		parent::__construct($AppName, $request);
@@ -175,11 +178,11 @@ class LogController extends Controller {
 
 						$acceptAction = $notification->createAction();
 						$acceptAction->setLabel('accept')
-							->setLink('/apps/phonetrack', 'GET');
+							->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'), IAction::TYPE_GET);
 
 						$declineAction = $notification->createAction();
 						$declineAction->setLabel('decline')
-							->setLink('/apps/phonetrack', 'GET');
+							->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'), IAction::TYPE_GET);
 
 						$notification->setApp(Application::APP_ID)
 							->setUser($aUserId)
@@ -307,11 +310,11 @@ class LogController extends Controller {
 
 						$acceptAction = $notification->createAction();
 						$acceptAction->setLabel('accept')
-							->setLink('/apps/phonetrack', 'GET');
+							->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'), IAction::TYPE_GET);
 
 						$declineAction = $notification->createAction();
 						$declineAction->setLabel('decline')
-							->setLink('/apps/phonetrack', 'GET');
+							->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'), IAction::TYPE_GET);
 
 						$notification->setApp(Application::APP_ID)
 							->setUser($aUserId)
@@ -475,11 +478,11 @@ class LogController extends Controller {
 
 							$acceptAction = $notification->createAction();
 							$acceptAction->setLabel('accept')
-								->setLink('/apps/phonetrack', 'GET');
+								->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'), IAction::TYPE_GET);
 
 							$declineAction = $notification->createAction();
 							$declineAction->setLabel('decline')
-								->setLink('/apps/phonetrack', 'GET');
+								->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'), IAction::TYPE_GET);
 
 							$notification->setApp(Application::APP_ID)
 								->setUser($aUserId)
@@ -597,11 +600,11 @@ class LogController extends Controller {
 
 							$acceptAction = $notification->createAction();
 							$acceptAction->setLabel('accept')
-								->setLink('/apps/phonetrack', 'GET');
+								->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'), IAction::TYPE_GET);
 
 							$declineAction = $notification->createAction();
 							$declineAction->setLabel('decline')
-								->setLink('/apps/phonetrack', 'GET');
+								->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'), IAction::TYPE_GET);
 
 							$notification->setApp(Application::APP_ID)
 								->setUser($aUserId)
@@ -705,11 +708,11 @@ class LogController extends Controller {
 
 				$acceptAction = $notification->createAction();
 				$acceptAction->setLabel('accept')
-					->setLink('/apps/phonetrack', 'GET');
+					->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'), IAction::TYPE_GET);
 
 				$declineAction = $notification->createAction();
 				$declineAction->setLabel('decline')
-					->setLink('/apps/phonetrack', 'GET');
+					->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'), IAction::TYPE_GET);
 
 				$notification->setApp(Application::APP_ID)
 					->setUser($userid)

--- a/lib/Controller/OldPageController.php
+++ b/lib/Controller/OldPageController.php
@@ -41,6 +41,7 @@ use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
+use OCP\Notification\IAction;
 use OCP\Notification\IManager as INotificationManager;
 use Psr\Log\LoggerInterface;
 use XMLParser;
@@ -2606,11 +2607,11 @@ class OldPageController extends Controller {
 
 					$acceptAction = $notification->createAction();
 					$acceptAction->setLabel('accept')
-						->setLink('/apps/phonetrack', 'GET');
+						->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'), IAction::TYPE_GET);
 
 					$declineAction = $notification->createAction();
 					$declineAction->setLabel('decline')
-						->setLink('/apps/phonetrack', 'GET');
+						->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'), IAction::TYPE_GET);
 
 					$notification->setApp(Application::APP_ID)
 						->setUser($userId)
@@ -2768,11 +2769,11 @@ class OldPageController extends Controller {
 
 				$acceptAction = $notification->createAction();
 				$acceptAction->setLabel('accept')
-					->setLink('/apps/phonetrack', 'GET');
+					->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'), IAction::TYPE_GET);
 
 				$declineAction = $notification->createAction();
 				$declineAction->setLabel('decline')
-					->setLink('/apps/phonetrack', 'GET');
+					->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'), IAction::TYPE_GET);
 
 				$notification->setApp(Application::APP_ID)
 					->setUser($userId)

--- a/lib/Migration/Version010000Date20260416223500.php
+++ b/lib/Migration/Version010000Date20260416223500.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\PhoneTrack\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\DB\Types;
+
+class Version010000Date20260417095600 extends SimpleMigrationStep {
+
+	public function __construct() {}
+
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {}
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		$schemaChanged = false;
+
+        // add missing columns for Device.php
+		if ($schema->hasTable('phonetrack_devices')) {
+			$table = $schema->getTable('phonetrack_devices');
+
+            if (!$table->hasColumn('line_enabled')) {
+                $table->addColumn('line_enabled', Types::INTEGER, [
+                    'notnull' => true,
+					'default' => 0,
+					'unsigned' => true,
+				]);
+                $schemaChanged = true;
+            }
+
+            if (!$table->hasColumn('auto_zoom')) {
+                $table->addColumn('auto_zoom', Types::INTEGER, [
+                    'notnull' => true,
+                    'default' => 0,
+                    'unsigned' => true,
+                ]);
+                $schemaChanged = true;
+            }
+
+            if (!$table->hasColumn('color_criteria')) {
+                $table->addColumn('color_criteria', Types::INTEGER, [
+                    'notnull' => true,
+                    'default' => 0,
+                    'unsigned' => true,
+                ]);
+                $schemaChanged = true;
+            }
+
+            if (!$table->hasColumn('enabled')) {
+                $table->addColumn('enabled', Types::INTEGER, [
+                    'notnull' => true,
+                    'default' => 0,
+                    'unsigned' => true,
+                ]);
+                $schemaChanged = true;
+            }
+
+            if (!$table->hasColumn('enabled')) {
+                $table->addColumn('enabled', Types::INTEGER, [
+                    'notnull' => true,
+                    'default' => 0,
+                    'unsigned' => true,
+                ]);
+                $schemaChanged = true;
+            }
+		}
+
+		return $schemaChanged ? $schema : null;
+	}
+
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {}
+}

--- a/lib/Migration/Version010000Date20260416223500.php
+++ b/lib/Migration/Version010000Date20260416223500.php
@@ -62,15 +62,6 @@ class Version010000Date20260417095600 extends SimpleMigrationStep {
                 ]);
                 $schemaChanged = true;
             }
-
-            if (!$table->hasColumn('enabled')) {
-                $table->addColumn('enabled', Types::INTEGER, [
-                    'notnull' => true,
-                    'default' => 0,
-                    'unsigned' => true,
-                ]);
-                $schemaChanged = true;
-            }
 		}
 
         // add missing Session.php column

--- a/lib/Migration/Version010000Date20260416223500.php
+++ b/lib/Migration/Version010000Date20260416223500.php
@@ -16,8 +16,10 @@ class Version010000Date20260417095600 extends SimpleMigrationStep {
 
 	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {}
 
+    /** Add the missing database columns for the Device and Session models
+     * that weren't added when upgrading from <1 to 1.0
+     */
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
-		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 		$schemaChanged = false;
 
@@ -70,6 +72,20 @@ class Version010000Date20260417095600 extends SimpleMigrationStep {
                 $schemaChanged = true;
             }
 		}
+
+        // add missing Session.php column
+        if ($schema->hasTable('phonetrack_sessions')) {
+            $table = $schema->getTable('phonetrack_sessions');
+
+            if (!$table->hasColumn('enabled')) {
+                $table->addColumn('enabled', Types::INTEGER, [
+                    'notnull' => true,
+                    'default' => 0,
+                    'unsigned' => true,
+                ]);
+                $schemaChanged = true;
+            }
+        }
 
 		return $schemaChanged ? $schema : null;
 	}

--- a/lib/Migration/Version010000Date20260416223500.php
+++ b/lib/Migration/Version010000Date20260416223500.php
@@ -10,7 +10,7 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\DB\Types;
 
-class Version010000Date20260417095600 extends SimpleMigrationStep {
+class Version010000Date20260416223500 extends SimpleMigrationStep {
 
 	public function __construct() {}
 

--- a/lib/Migration/Version010000Date20260416223500.php
+++ b/lib/Migration/Version010000Date20260416223500.php
@@ -5,25 +5,22 @@ declare(strict_types=1);
 namespace OCA\PhoneTrack\Migration;
 
 use Closure;
-use OCP\DB\ISchemaWrapper;
+use Doctrine\DBAL\Types\Type;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\DB\Types;
 
 class Version010000Date20260416223500 extends SimpleMigrationStep {
 
-	public function __construct() {}
-
-	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {}
-
-    /** Add the missing database columns for the Device and Session models
+    /**
+     * Add the missing database columns for the Device and Session models
      * that weren't added when upgrading from <1 to 1.0
+     * If they are already there, make sure they have the right type and make them unsigned
      */
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
 		$schema = $schemaClosure();
 		$schemaChanged = false;
 
-        // add missing columns for Device.php
 		if ($schema->hasTable('phonetrack_devices')) {
 			$table = $schema->getTable('phonetrack_devices');
 
@@ -34,6 +31,13 @@ class Version010000Date20260416223500 extends SimpleMigrationStep {
 					'unsigned' => true,
 				]);
                 $schemaChanged = true;
+            } else {
+                $column = $table->getColumn('line_enabled');
+                if ($column->getType() !== Types::INTEGER || !$column->getUnsigned()) {
+                    $column->setType(Type::getType(Types::INTEGER));
+                    $column->setUnsigned(true);
+                    $schemaChanged = true;
+                }
             }
 
             if (!$table->hasColumn('auto_zoom')) {
@@ -43,6 +47,13 @@ class Version010000Date20260416223500 extends SimpleMigrationStep {
                     'unsigned' => true,
                 ]);
                 $schemaChanged = true;
+            } else {
+                $column = $table->getColumn('auto_zoom');
+                if ($column->getType() !== Types::INTEGER || !$column->getUnsigned()) {
+                    $column->setType(Type::getType(Types::INTEGER));
+                    $column->setUnsigned(true);
+                    $schemaChanged = true;
+                }
             }
 
             if (!$table->hasColumn('color_criteria')) {
@@ -52,6 +63,13 @@ class Version010000Date20260416223500 extends SimpleMigrationStep {
                     'unsigned' => true,
                 ]);
                 $schemaChanged = true;
+            } else {
+                $column = $table->getColumn('color_criteria');
+                if ($column->getType() !== Types::INTEGER || !$column->getUnsigned()) {
+                    $column->setType(Type::getType(Types::INTEGER));
+                    $column->setUnsigned(true);
+                    $schemaChanged = true;
+                }
             }
 
             if (!$table->hasColumn('enabled')) {
@@ -61,10 +79,16 @@ class Version010000Date20260416223500 extends SimpleMigrationStep {
                     'unsigned' => true,
                 ]);
                 $schemaChanged = true;
+            } else {
+                $column = $table->getColumn('enabled');
+                if ($column->getType() !== Types::INTEGER || !$column->getUnsigned()) {
+                    $column->setType(Type::getType(Types::INTEGER));
+                    $column->setUnsigned(true);
+                    $schemaChanged = true;
+                }
             }
 		}
 
-        // add missing Session.php column
         if ($schema->hasTable('phonetrack_sessions')) {
             $table = $schema->getTable('phonetrack_sessions');
 
@@ -75,11 +99,16 @@ class Version010000Date20260416223500 extends SimpleMigrationStep {
                     'unsigned' => true,
                 ]);
                 $schemaChanged = true;
+            } else {
+                $column = $table->getColumn('enabled');
+                if ($column->getType() !== Types::INTEGER || !$column->getUnsigned()) {
+                    $column->setType(Type::getType(Types::INTEGER));
+                    $column->setUnsigned(true);
+                    $schemaChanged = true;
+                }
             }
         }
 
 		return $schemaChanged ? $schema : null;
 	}
-
-	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {}
 }

--- a/lib/Migration/Version010200Date20260416223500.php
+++ b/lib/Migration/Version010200Date20260416223500.php
@@ -10,7 +10,7 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\DB\Types;
 
-class Version010000Date20260416223500 extends SimpleMigrationStep {
+class Version010200Date20260416223500 extends SimpleMigrationStep {
 
     /**
      * Add the missing database columns for the Device and Session models

--- a/lib/Migration/Version010200Date20260416223500.php
+++ b/lib/Migration/Version010200Date20260416223500.php
@@ -6,17 +6,17 @@ namespace OCA\PhoneTrack\Migration;
 
 use Closure;
 use Doctrine\DBAL\Types\Type;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
-use OCP\DB\Types;
 
 class Version010200Date20260416223500 extends SimpleMigrationStep {
 
-    /**
-     * Add the missing database columns for the Device and Session models
-     * that weren't added when upgrading from <1 to 1.0
-     * If they are already there, make sure they have the right type and make them unsigned
-     */
+	/**
+	 * Add the missing database columns for the Device and Session models
+	 * that weren't added when upgrading from <1 to 1.0
+	 * If they are already there, make sure they have the right type and make them unsigned
+	 */
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
 		$schema = $schemaClosure();
 		$schemaChanged = false;
@@ -24,90 +24,90 @@ class Version010200Date20260416223500 extends SimpleMigrationStep {
 		if ($schema->hasTable('phonetrack_devices')) {
 			$table = $schema->getTable('phonetrack_devices');
 
-            if (!$table->hasColumn('line_enabled')) {
-                $table->addColumn('line_enabled', Types::INTEGER, [
-                    'notnull' => true,
+			if (!$table->hasColumn('line_enabled')) {
+				$table->addColumn('line_enabled', Types::INTEGER, [
+					'notnull' => true,
 					'default' => 0,
 					'unsigned' => true,
 				]);
-                $schemaChanged = true;
-            } else {
-                $column = $table->getColumn('line_enabled');
-                if ($column->getType() !== Types::INTEGER || !$column->getUnsigned()) {
-                    $column->setType(Type::getType(Types::INTEGER));
-                    $column->setUnsigned(true);
-                    $schemaChanged = true;
-                }
-            }
+				$schemaChanged = true;
+			} else {
+				$column = $table->getColumn('line_enabled');
+				if ($column->getType() !== Types::INTEGER || !$column->getUnsigned()) {
+					$column->setType(Type::getType(Types::INTEGER));
+					$column->setUnsigned(true);
+					$schemaChanged = true;
+				}
+			}
 
-            if (!$table->hasColumn('auto_zoom')) {
-                $table->addColumn('auto_zoom', Types::INTEGER, [
-                    'notnull' => true,
-                    'default' => 0,
-                    'unsigned' => true,
-                ]);
-                $schemaChanged = true;
-            } else {
-                $column = $table->getColumn('auto_zoom');
-                if ($column->getType() !== Types::INTEGER || !$column->getUnsigned()) {
-                    $column->setType(Type::getType(Types::INTEGER));
-                    $column->setUnsigned(true);
-                    $schemaChanged = true;
-                }
-            }
+			if (!$table->hasColumn('auto_zoom')) {
+				$table->addColumn('auto_zoom', Types::INTEGER, [
+					'notnull' => true,
+					'default' => 0,
+					'unsigned' => true,
+				]);
+				$schemaChanged = true;
+			} else {
+				$column = $table->getColumn('auto_zoom');
+				if ($column->getType() !== Types::INTEGER || !$column->getUnsigned()) {
+					$column->setType(Type::getType(Types::INTEGER));
+					$column->setUnsigned(true);
+					$schemaChanged = true;
+				}
+			}
 
-            if (!$table->hasColumn('color_criteria')) {
-                $table->addColumn('color_criteria', Types::INTEGER, [
-                    'notnull' => true,
-                    'default' => 0,
-                    'unsigned' => true,
-                ]);
-                $schemaChanged = true;
-            } else {
-                $column = $table->getColumn('color_criteria');
-                if ($column->getType() !== Types::INTEGER || !$column->getUnsigned()) {
-                    $column->setType(Type::getType(Types::INTEGER));
-                    $column->setUnsigned(true);
-                    $schemaChanged = true;
-                }
-            }
+			if (!$table->hasColumn('color_criteria')) {
+				$table->addColumn('color_criteria', Types::INTEGER, [
+					'notnull' => true,
+					'default' => 0,
+					'unsigned' => true,
+				]);
+				$schemaChanged = true;
+			} else {
+				$column = $table->getColumn('color_criteria');
+				if ($column->getType() !== Types::INTEGER || !$column->getUnsigned()) {
+					$column->setType(Type::getType(Types::INTEGER));
+					$column->setUnsigned(true);
+					$schemaChanged = true;
+				}
+			}
 
-            if (!$table->hasColumn('enabled')) {
-                $table->addColumn('enabled', Types::INTEGER, [
-                    'notnull' => true,
-                    'default' => 0,
-                    'unsigned' => true,
-                ]);
-                $schemaChanged = true;
-            } else {
-                $column = $table->getColumn('enabled');
-                if ($column->getType() !== Types::INTEGER || !$column->getUnsigned()) {
-                    $column->setType(Type::getType(Types::INTEGER));
-                    $column->setUnsigned(true);
-                    $schemaChanged = true;
-                }
-            }
+			if (!$table->hasColumn('enabled')) {
+				$table->addColumn('enabled', Types::INTEGER, [
+					'notnull' => true,
+					'default' => 0,
+					'unsigned' => true,
+				]);
+				$schemaChanged = true;
+			} else {
+				$column = $table->getColumn('enabled');
+				if ($column->getType() !== Types::INTEGER || !$column->getUnsigned()) {
+					$column->setType(Type::getType(Types::INTEGER));
+					$column->setUnsigned(true);
+					$schemaChanged = true;
+				}
+			}
 		}
 
-        if ($schema->hasTable('phonetrack_sessions')) {
-            $table = $schema->getTable('phonetrack_sessions');
+		if ($schema->hasTable('phonetrack_sessions')) {
+			$table = $schema->getTable('phonetrack_sessions');
 
-            if (!$table->hasColumn('enabled')) {
-                $table->addColumn('enabled', Types::INTEGER, [
-                    'notnull' => true,
-                    'default' => 0,
-                    'unsigned' => true,
-                ]);
-                $schemaChanged = true;
-            } else {
-                $column = $table->getColumn('enabled');
-                if ($column->getType() !== Types::INTEGER || !$column->getUnsigned()) {
-                    $column->setType(Type::getType(Types::INTEGER));
-                    $column->setUnsigned(true);
-                    $schemaChanged = true;
-                }
-            }
-        }
+			if (!$table->hasColumn('enabled')) {
+				$table->addColumn('enabled', Types::INTEGER, [
+					'notnull' => true,
+					'default' => 0,
+					'unsigned' => true,
+				]);
+				$schemaChanged = true;
+			} else {
+				$column = $table->getColumn('enabled');
+				if ($column->getType() !== Types::INTEGER || !$column->getUnsigned()) {
+					$column->setType(Type::getType(Types::INTEGER));
+					$column->setUnsigned(true);
+					$schemaChanged = true;
+				}
+			}
+		}
 
 		return $schemaChanged ? $schema : null;
 	}

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -51,7 +51,7 @@ class Notifier implements INotifier {
 
 				$notification->setParsedSubject($content)
 					->setIcon($this->url->getAbsoluteURL($this->url->imagePath(Application::APP_ID, 'app_black.svg')))
-					->setLink($this->url->linkToRouteAbsolute('phonetrack.page.index'));
+					->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'));
 				return $notification;
 			case 'leave_geofence':
 				$p = $notification->getSubjectParameters();
@@ -59,7 +59,7 @@ class Notifier implements INotifier {
 
 				$notification->setParsedSubject($content)
 					->setIcon($this->url->getAbsoluteURL($this->url->imagePath(Application::APP_ID, 'app_black.svg')))
-					->setLink($this->url->linkToRouteAbsolute('phonetrack.page.index'));
+					->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'));
 				return $notification;
 
 			case 'close_proxim':
@@ -68,7 +68,7 @@ class Notifier implements INotifier {
 
 				$notification->setParsedSubject($content)
 					->setIcon($this->url->getAbsoluteURL($this->url->imagePath(Application::APP_ID, 'app_black.svg')))
-					->setLink($this->url->linkToRouteAbsolute('phonetrack.page.index'));
+					->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'));
 				return $notification;
 			case 'far_proxim':
 				$p = $notification->getSubjectParameters();
@@ -76,7 +76,7 @@ class Notifier implements INotifier {
 
 				$notification->setParsedSubject($content)
 					->setIcon($this->url->getAbsoluteURL($this->url->imagePath(Application::APP_ID, 'app_black.svg')))
-					->setLink($this->url->linkToRouteAbsolute('phonetrack.page.index'));
+					->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'));
 				return $notification;
 
 			case 'quota_reached':
@@ -85,7 +85,7 @@ class Notifier implements INotifier {
 
 				$notification->setParsedSubject($content)
 					->setIcon($this->url->getAbsoluteURL($this->url->imagePath(Application::APP_ID, 'app_black.svg')))
-					->setLink($this->url->linkToRouteAbsolute('phonetrack.page.index'));
+					->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'));
 				return $notification;
 
 			case 'add_user_share':
@@ -94,7 +94,7 @@ class Notifier implements INotifier {
 
 				$notification->setParsedSubject($content)
 					->setIcon($this->url->getAbsoluteURL($this->url->imagePath(Application::APP_ID, 'app_black.svg')))
-					->setLink($this->url->linkToRouteAbsolute('phonetrack.page.index'));
+					->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'));
 				return $notification;
 
 			case 'delete_user_share':
@@ -103,7 +103,7 @@ class Notifier implements INotifier {
 
 				$notification->setParsedSubject($content)
 					->setIcon($this->url->getAbsoluteURL($this->url->imagePath(Application::APP_ID, 'app_black.svg')))
-					->setLink($this->url->linkToRouteAbsolute('phonetrack.page.index'));
+					->setLink($this->url->linkToRouteAbsolute(Application::APP_ID . '.page.index'));
 				return $notification;
 
 			default:

--- a/tests/php/controller/OldPageControllerTest.php
+++ b/tests/php/controller/OldPageControllerTest.php
@@ -179,6 +179,7 @@ class OldPageControllerTest extends TestCase {
 			Server::get(ShareMapper::class),
 			Server::get(IDBConnection::class),
 			Server::get(IMailer::class),
+			Server::get(IURLGenerator::class),
 			'test'
 		);
 
@@ -200,6 +201,7 @@ class OldPageControllerTest extends TestCase {
 			Server::get(ShareMapper::class),
 			Server::get(IDBConnection::class),
 			Server::get(IMailer::class),
+			Server::get(IURLGenerator::class),
 			'test2'
 		);
 

--- a/vendor-bin/psalm/composer.lock
+++ b/vendor-bin/psalm/composer.lock
@@ -600,24 +600,27 @@
         },
         {
             "name": "amphp/serialization",
-            "version": "v1.0.0",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/serialization.git",
-                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1"
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/serialization/zipball/693e77b2fb0b266c3c7d622317f881de44ae94a1",
-                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1",
+                "url": "https://api.github.com/repos/amphp/serialization/zipball/fdf2834d78cebb0205fb2672676c1b1eb84371f0",
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.4"
             },
             "require-dev": {
-                "amphp/php-cs-fixer-config": "dev-master",
-                "phpunit/phpunit": "^9 || ^8 || ^7"
+                "amphp/php-cs-fixer-config": "^2",
+                "ext-json": "*",
+                "ext-zlib": "*",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -652,22 +655,28 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/serialization/issues",
-                "source": "https://github.com/amphp/serialization/tree/master"
+                "source": "https://github.com/amphp/serialization/tree/v1.1.0"
             },
-            "time": "2020-03-25T21:39:07+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-05T15:59:53+00:00"
         },
         {
             "name": "amphp/socket",
-            "version": "v2.3.1",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/socket.git",
-                "reference": "58e0422221825b79681b72c50c47a930be7bf1e1"
+                "reference": "dadb63c5d3179fd83803e29dfeac27350e619314"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/socket/zipball/58e0422221825b79681b72c50c47a930be7bf1e1",
-                "reference": "58e0422221825b79681b72c50c47a930be7bf1e1",
+                "url": "https://api.github.com/repos/amphp/socket/zipball/dadb63c5d3179fd83803e29dfeac27350e619314",
+                "reference": "dadb63c5d3179fd83803e29dfeac27350e619314",
                 "shasum": ""
             },
             "require": {
@@ -676,17 +685,17 @@
                 "amphp/dns": "^2",
                 "ext-openssl": "*",
                 "kelunik/certificate": "^1.1",
-                "league/uri": "^6.5 | ^7",
-                "league/uri-interfaces": "^2.3 | ^7",
+                "league/uri": "^7",
+                "league/uri-interfaces": "^7",
                 "php": ">=8.1",
-                "revolt/event-loop": "^1 || ^0.2"
+                "revolt/event-loop": "^1"
             },
             "require-dev": {
                 "amphp/php-cs-fixer-config": "^2",
                 "amphp/phpunit-util": "^3",
                 "amphp/process": "^2",
                 "phpunit/phpunit": "^9",
-                "psalm/phar": "5.20"
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -730,7 +739,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/socket/issues",
-                "source": "https://github.com/amphp/socket/tree/v2.3.1"
+                "source": "https://github.com/amphp/socket/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -738,7 +747,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-21T14:33:03+00:00"
+            "time": "2026-04-19T15:09:56+00:00"
         },
         {
             "name": "amphp/sync",
@@ -1172,29 +1181,29 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<=7.5 || >=13"
+                "phpunit/phpunit": "<=7.5 || >=14"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^12 || ^13",
-                "phpstan/phpstan": "1.4.10 || 2.1.11",
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
                 "phpstan/phpstan-phpunit": "^1.0 || ^2",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
                 "psr/log": "^1 || ^2 || ^3"
             },
             "suggest": {
@@ -1214,9 +1223,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
-            "time": "2025-04-07T20:06:18+00:00"
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "felixfbecker/language-server-protocol",
@@ -1395,20 +1404,20 @@
         },
         {
             "name": "league/uri",
-            "version": "7.8.0",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "4436c6ec8d458e4244448b069cc572d088230b76"
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/4436c6ec8d458e4244448b069cc572d088230b76",
-                "reference": "4436c6ec8d458e4244448b069cc572d088230b76",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
                 "shasum": ""
             },
             "require": {
-                "league/uri-interfaces": "^7.8",
+                "league/uri-interfaces": "^7.8.1",
                 "php": "^8.1",
                 "psr/http-factory": "^1"
             },
@@ -1481,7 +1490,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/7.8.0"
+                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
             },
             "funding": [
                 {
@@ -1489,20 +1498,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-14T17:24:56+00:00"
+            "time": "2026-03-15T20:22:25+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "7.8.0",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "c5c5cd056110fc8afaba29fa6b72a43ced42acd4"
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/c5c5cd056110fc8afaba29fa6b72a43ced42acd4",
-                "reference": "c5c5cd056110fc8afaba29fa6b72a43ced42acd4",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
                 "shasum": ""
             },
             "require": {
@@ -1565,7 +1574,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.0"
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
             },
             "funding": [
                 {
@@ -1573,20 +1582,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-15T06:54:53+00:00"
+            "time": "2026-03-08T20:05:35+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v5.0.0",
+            "version": "v5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "8c64d8d444a5d764c641ebe97e0e3bc72b25bf6c"
+                "reference": "980674efdda65913492d29a8fd51c82270dd37bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/8c64d8d444a5d764c641ebe97e0e3bc72b25bf6c",
-                "reference": "8c64d8d444a5d764c641ebe97e0e3bc72b25bf6c",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/980674efdda65913492d29a8fd51c82270dd37bb",
+                "reference": "980674efdda65913492d29a8fd51c82270dd37bb",
                 "shasum": ""
             },
             "require": {
@@ -1622,9 +1631,9 @@
             "support": {
                 "email": "cweiske@cweiske.de",
                 "issues": "https://github.com/cweiske/jsonmapper/issues",
-                "source": "https://github.com/cweiske/jsonmapper/tree/v5.0.0"
+                "source": "https://github.com/cweiske/jsonmapper/tree/v5.0.1"
             },
-            "time": "2024-09-08T10:20:00+00:00"
+            "time": "2026-02-22T16:28:03+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -1739,16 +1748,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "6.0.1",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "2f5cbed597cb261d1ea458f3da3a9ad32e670b1e"
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2f5cbed597cb261d1ea458f3da3a9ad32e670b1e",
-                "reference": "2f5cbed597cb261d1ea458f3da3a9ad32e670b1e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582",
                 "shasum": ""
             },
             "require": {
@@ -1798,9 +1807,9 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.1"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.3"
             },
-            "time": "2026-01-20T15:30:42+00:00"
+            "time": "2026-03-18T20:49:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -2327,16 +2336,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.4",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "41e38717ac1dd7a46b6bda7d6a82af2d98a78894"
+                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/41e38717ac1dd7a46b6bda7d6a82af2d98a78894",
-                "reference": "41e38717ac1dd7a46b6bda7d6a82af2d98a78894",
+                "url": "https://api.github.com/repos/symfony/console/zipball/1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
+                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
                 "shasum": ""
             },
             "require": {
@@ -2401,7 +2410,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.4"
+                "source": "https://github.com/symfony/console/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -2421,7 +2430,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-13T11:36:38+00:00"
+            "time": "2026-03-30T13:54:39+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2492,16 +2501,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.4.0",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "d551b38811096d0be9c4691d406991b47c0c630a"
+                "reference": "58b9790d12f9670b7f53a1c1738febd3108970a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d551b38811096d0be9c4691d406991b47c0c630a",
-                "reference": "d551b38811096d0be9c4691d406991b47c0c630a",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/58b9790d12f9670b7f53a1c1738febd3108970a5",
+                "reference": "58b9790d12f9670b7f53a1c1738febd3108970a5",
                 "shasum": ""
             },
             "require": {
@@ -2538,7 +2547,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.4.0"
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -2558,20 +2567,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-27T13:27:24+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -2621,7 +2630,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -2641,20 +2650,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
+                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
                 "shasum": ""
             },
             "require": {
@@ -2703,7 +2712,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -2723,11 +2732,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -2788,7 +2797,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -2812,16 +2821,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
                 "shasum": ""
             },
             "require": {
@@ -2873,7 +2882,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -2893,20 +2902,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-04-10T17:25:58+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191"
+                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/d8ced4d875142b6a7426000426b8abc631d6b191",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06",
                 "shasum": ""
             },
             "require": {
@@ -2953,7 +2962,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -2973,7 +2982,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-24T13:30:11+00:00"
+            "time": "2026-04-10T18:47:49+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -3064,16 +3073,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.4",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "1c4b10461bf2ec27537b5f36105337262f5f5d6f"
+                "reference": "114ac57257d75df748eda23dd003878080b8e688"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/1c4b10461bf2ec27537b5f36105337262f5f5d6f",
-                "reference": "1c4b10461bf2ec27537b5f36105337262f5f5d6f",
+                "url": "https://api.github.com/repos/symfony/string/zipball/114ac57257d75df748eda23dd003878080b8e688",
+                "reference": "114ac57257d75df748eda23dd003878080b8e688",
                 "shasum": ""
             },
             "require": {
@@ -3131,7 +3140,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.4"
+                "source": "https://github.com/symfony/string/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -3151,20 +3160,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-12T10:54:30+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.15.0",
+            "version": "6.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "204d06619833a297b402cbc66be7f2df74437db4"
+                "reference": "f1f5de594dc76faf8784e02d3dc4716c91c6f6ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/204d06619833a297b402cbc66be7f2df74437db4",
-                "reference": "204d06619833a297b402cbc66be7f2df74437db4",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f1f5de594dc76faf8784e02d3dc4716c91c6f6ac",
+                "reference": "f1f5de594dc76faf8784e02d3dc4716c91c6f6ac",
                 "shasum": ""
             },
             "require": {
@@ -3188,7 +3197,7 @@
                 "netresearch/jsonmapper": "^5.0",
                 "nikic/php-parser": "^5.0.0",
                 "php": "~8.1.31 || ~8.2.27 || ~8.3.16 || ~8.4.3 || ~8.5.0",
-                "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+                "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
                 "spatie/array-to-xml": "^2.17.0 || ^3.0",
                 "symfony/console": "^6.0 || ^7.0 || ^8.0",
                 "symfony/filesystem": "~6.3.12 || ~6.4.3 || ^7.0.3 || ^8.0",
@@ -3269,20 +3278,20 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2026-01-30T13:53:17+00:00"
+            "time": "2026-03-19T10:56:09+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "2.1.2",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649"
+                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
-                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
+                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
                 "shasum": ""
             },
             "require": {
@@ -3329,9 +3338,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.1.2"
+                "source": "https://github.com/webmozarts/assert/tree/2.3.0"
             },
-            "time": "2026-01-13T14:02:24+00:00"
+            "time": "2026-04-11T10:33:05+00:00"
         }
     ],
     "aliases": [],
@@ -3346,5 +3355,5 @@
     "platform-overrides": {
         "php": "8.2.27"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Fixes #144 

When upgrading to v1.0, having originally installed <v1.0 installed, some database columns for the `Device` and `Session` models aren't added. Those columns are: 

```
phonetrack_devices
------------------
line_enabled
auto_zoom
color_criteria
enabled
```

```
phonetrack_sessions
-------------------
enabled
```

I looked through all the other database tables and no columns for any other classes appear to be missing.

I have created a new migration that adds these columns if they don't exist. I wasn't too sure on what to put for the `notnull`, `default`, or `unsigned` parameters so I copied them from an earlier migration:

```
'notnull' => true,
'default' => 0,
'unsigned' => true
```

Through manual testing it seems everything is working as it should! The show line and auto zoom features are now working and there are no errors in Firefox's JavaScript console or the Nextcloud logs. 

*note: I did _not_ vibe code this!