### PR TITLE
Update OwnTracks Empty Message Response

### DIFF
--- a/lib/Controller/LogController.php
+++ b/lib/Controller/LogController.php
@@ -1546,7 +1546,7 @@ class LogController extends Controller {
 	): JSONResponse {
 		if (is_null($lat) || is_null($lon)) {
 			// empty message (control message?) - ignore
-			return new JSONResponse(['result' => 'ok']);
+			return new JSONResponse([]);
 		}
 		$dname = $this->chooseDeviceName($devicename, $tid);
 		if ($batt !== null) {


### PR DESCRIPTION
When OwnTracks makes a call that doesn't have latitude or longitude, return an empty array `[]` instead of `{"result":"ok"}`

This allows PhoneTrack to work with [recent OwnTracks changes](https://github.com/owntracks/android/issues/2242#issuecomment-4458629589).
