### PR TITLE
FIX: Warning of missing vue_index_url

### DIFF
--- a/templates/maincontent.php
+++ b/templates/maincontent.php
@@ -43,7 +43,7 @@
 							<i class="fa fa-plus-circle" aria-hidden="true"></i>
 							<?php p($l->t('Create session')); ?>
 						</button>
-						<a href="<?php p($_['vue_index_url']); ?>">
+						<a href="<?php p($_['vue_index_url'] ?? ''); ?>">
 							<button id="goToNewInterface_">
 								<!-- switch when the new interface is feature-complete and stable -->
 								<!--i class="fa fa-wand-magic-sparkles" aria-hidden="true"></i-->


### PR DESCRIPTION
FIX: Using null‑coalescing operator: If vue_index_url is not defined, fall back to ''.
Nextcloud's logs otherwise pollute with warnings: "Undefined array key "vue_index_url" at /nextcloud/apps/phonetrack/templates/maincontent.php"