### PR TITLE
Fix import session, test rollback scenarios

### DIFF
--- a/lib/Db/PointMapper.php
+++ b/lib/Db/PointMapper.php
@@ -401,7 +401,7 @@ class PointMapper extends QBMapper {
 				$point[6] ? $this->db->quote($point[6]) : 'NULL',
 				$point[4] ? $this->db->quote($point[4]) : 'NULL',
 				$point[9] ? $this->db->quote($point[9]) : 'NULL',
-				$point[8] ? $this->db->quote($point[8]) : 'NULL',
+				$point[8] ? $this->db->quote($point[8]) : $this->db->quote(''),
 				$point[5] ? $this->db->quote($point[5]) : 'NULL',
 				$point[7] ? $this->db->quote($point[7]) : 'NULL',
 			]) . ')';

--- a/lib/Db/ProximMapper.php
+++ b/lib/Db/ProximMapper.php
@@ -79,12 +79,13 @@ class ProximMapper extends QBMapper {
 	public function deleteByDeviceId(int $deviceId): int {
 		$qb = $this->db->getQueryBuilder();
 
-		$qb->delete($this->getTableName());
-
-		$or = $qb->expr()->orx();
-		$or->add($qb->expr()->eq('deviceid1', $qb->createNamedParameter($deviceId, IQueryBuilder::PARAM_INT)));
-		$or->add($qb->expr()->eq('deviceid2', $qb->createNamedParameter($deviceId, IQueryBuilder::PARAM_INT)));
-		$qb->where($or);
+		$qb->delete($this->getTableName())
+			->where(
+				$qb->expr()->orX(
+					$qb->expr()->eq('deviceid1', $qb->createNamedParameter($deviceId, IQueryBuilder::PARAM_INT)),
+					$qb->expr()->eq('deviceid2', $qb->createNamedParameter($deviceId, IQueryBuilder::PARAM_INT))
+				)
+			);
 
 		$nbDeleted = $qb->executeStatement();
 		return $nbDeleted;

--- a/lib/Service/SessionService.php
+++ b/lib/Service/SessionService.php
@@ -1195,11 +1195,13 @@ class SessionService {
 		}
 		if (str_ends_with($file->getName(), '.gpx') || str_ends_with($file->getName(), '.GPX')) {
 			$sessionName = str_replace(['.gpx', '.GPX'], '', $file->getName());
-			$session = $this->createSession($userId, $sessionName);
+			$this->db->beginTransaction();
 			try {
+				$session = $this->createSession($userId, $sessionName);
 				$this->importGpxService->importGpx($file, $session->getId(), $session->getToken());
+				$this->db->commit();
 			} catch (\Exception|\Throwable $e) {
-				$this->deleteSession($session);
+				$this->db->rollBack();
 				throw $e;
 			}
 		} else {

--- a/tests/php/controller/PageControllerTest.php
+++ b/tests/php/controller/PageControllerTest.php
@@ -23,6 +23,7 @@ use OCA\PhoneTrack\Service\ToolsService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Services\IInitialState;
+use OCP\Files\IRootFolder;
 use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -201,6 +202,73 @@ class PageControllerTest extends TestCase {
 
 		$data = $deleteResponse->getData();
 		$this->assertEquals('session_not_found', $data['error']);
+	}
+
+	public function testImportGpxSession(): void {
+		$userFolder = Server::get(IRootFolder::class)->getUserFolder(self::USER_1);
+		$txt = '<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1">
+ <trk>
+  <name>test track</name>
+  <trkseg>
+   <trkpt lat="47.5" lon="-2.9">
+    <time>2018-09-13T10:29:41Z</time>
+   </trkpt>
+   <trkpt lat="50.0" lon="11.9">
+    <time>2018-09-13T10:29:45Z</time>
+   </trkpt>
+  </trkseg>
+ </trk>
+</gpx>';
+		$userFolder->newFile('import-ok.gpx')->putContent($txt);
+
+		$response = $this->pageController->importSession('/import-ok.gpx');
+
+		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
+		$data = $response->getData();
+		$this->assertArrayHasKey('id', $data);
+		$this->assertEquals('import-ok', $data['name']);
+
+		$session = $this->sessionMapper->getUserSessionById(self::USER_1, $data['id']);
+		$this->assertEquals('import-ok', $session->getName());
+	}
+
+	public function testImportGpxSessionRollsBackOnFailure(): void {
+		$userFolder = Server::get(IRootFolder::class)->getUserFolder(self::USER_1);
+		// GPX with no <trk> element triggers "no_device_to_import" inside importGpx
+		$txt = '<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1">
+ <metadata>
+  <name>no tracks</name>
+ </metadata>
+</gpx>';
+		$userFolder->newFile('import-fail.gpx')->putContent($txt);
+
+		$response = $this->pageController->importSession('/import-fail.gpx');
+
+		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertEquals('no_device_to_import', $response->getData()['error']);
+
+		// session creation must have been rolled back, no orphan session
+		$sessions = $this->sessionMapper->findByUser(self::USER_1);
+		$this->assertCount(0, $sessions);
+	}
+
+	public function testImportGpxSessionReturnsFileNotFoundForMissingFile(): void {
+		$response = $this->pageController->importSession('/does-not-exist.gpx');
+
+		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertEquals('file_not_found', $response->getData()['error']);
+	}
+
+	public function testImportGpxSessionReturnsInvalidFormatForNonGpxFile(): void {
+		$userFolder = Server::get(IRootFolder::class)->getUserFolder(self::USER_1);
+		$userFolder->newFile('not-a-gpx.txt')->putContent('hello');
+
+		$response = $this->pageController->importSession('/not-a-gpx.txt');
+
+		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertEquals('invalid_format', $response->getData()['error']);
 	}
 
 	private function deleteSessionsForUser(string $userId): void {

--- a/tests/php/controller/PageControllerTest.php
+++ b/tests/php/controller/PageControllerTest.php
@@ -233,6 +233,32 @@ class PageControllerTest extends TestCase {
 		$this->assertEquals('import-ok', $session->getName());
 	}
 
+	public function testImportGpxSessionWithoutUseragent(): void {
+		$userFolder = Server::get(IRootFolder::class)->getUserFolder(self::USER_1);
+		// minimal GPX with no <extensions>/<useragent> on the trkpts
+		// the useragent column is NOT NULL in the schema, so the import
+		// must substitute a non-null default rather than writing NULL
+		$txt = '<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1">
+ <trk>
+  <name>no useragent</name>
+  <trkseg>
+   <trkpt lat="47.5" lon="-2.9">
+    <time>2018-09-13T10:29:41Z</time>
+   </trkpt>
+  </trkseg>
+ </trk>
+</gpx>';
+		$userFolder->newFile('import-no-ua.gpx')->putContent($txt);
+
+		$response = $this->pageController->importSession('/import-no-ua.gpx');
+
+		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
+		$data = $response->getData();
+		$this->assertArrayHasKey('id', $data);
+		$this->assertEquals('import-no-ua', $data['name']);
+	}
+
 	public function testImportGpxSessionRollsBackOnFailure(): void {
 		$userFolder = Server::get(IRootFolder::class)->getUserFolder(self::USER_1);
 		// GPX with no <trk> element triggers "no_device_to_import" inside importGpx


### PR DESCRIPTION
closes #162

* Fix the orX call: Calling `$qb->expr()->orX();` with no arguments is now deprecated (or even throws).
* Fix the rollback: This PR wraps the GPX import in a transaction so we don't have to explicitly delete the created session on failure, the rollback takes care of it. It prevents the dirty table reads.
* Allow missing user agents in imported file. This made the import fail when providing a classic GPX file with no
``` xml
<extensions>
     <useragent>whatever</useragent>
</extensions>
```
in the `<trkpt>`