### PR TITLE
fix(csp): allow worker-src 'self' for the maplibre-gl worker

### DIFF
--- a/lib/Service/MapService.php
+++ b/lib/Service/MapService.php
@@ -55,6 +55,7 @@ class MapService {
 			// nominatim (not needed, we proxy requests through the server)
 			//->addAllowedConnectDomain('https://nominatim.openstreetmap.org')
 			// maplibre-gl
+			->addAllowedWorkerSrcDomain("'self'")
 			->addAllowedWorkerSrcDomain('blob:');
 
 		foreach ($extraTileServers as $ts) {


### PR DESCRIPTION
## Summary
Track lines/points don't render on any map view that uses `MaplibreMap.vue`
(main app, public share) whenever the map needs its worker for anything
beyond a single fallback marker. The worker script itself is blocked by CSP.

<img width="2299" height="42" alt="SCR-20260815-lojs" src="https://github.com/user-attachments/assets/37f3c04d-a0f0-4b66-8e3d-24f25820a7ee" />

- Root cause: `MapService::addPageCsp()` only grants `worker-src blob:`, but
  `MaplibreMap.vue` loads the worker via `setWorkerUrl(workerUrl)` from a
  same-origin static asset (Vite's `?worker&url` import) — not a `blob:` URL —
  so it needs `worker-src 'self'` instead.
- This is a regression from 4a92d5d ("migrate to maplibre-gl 6"), which
  switched the worker-loading approach but didn't update the CSP to match.
- Fix: add `'self'` to the worker-src allowlist alongside `blob:`.

## Repro
1. Import or log a device with more than a handful of points.
2. Open the session on a map view using `MaplibreMap.vue`.
3. Only the last known position marker renders — the track line/other points
   don't, regardless of point count.
4. Browser console shows: